### PR TITLE
Fix Spotify integration for February 2026 Web API changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1532,7 +1532,7 @@ dependencies = [
 
 [[package]]
 name = "sync_dis_boi"
-version = "0.6.2"
+version = "0.6.7"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sync_dis_boi"
-version = "0.6.2"
+version = "0.6.7"
 edition = "2024"
 license-file = "LICENSE.txt"
 description = "a music streaming platform synchronization tool"

--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ After the first authorization, the OAuth token will be cached in `~/.config/Sync
 
 Notes:
 - After authorizing access for your Spotify account, SyncDisBoi will open the 'http://127.0.0.1:8888/callback' URL in your browser. If you get an 'Unable to connect' response this is normal as the server is quickly opened and shutdown once it receives the auth code.
+- Spotify Web API changes in February 2026 replaced playlist track endpoints with playlist item endpoints (`/playlists/{id}/items`) and migrated likes/follow operations to `/me/library`.
+- On Spotify Development Mode, playlist item details are only available for playlists you own or collaborate on. Followed-only playlists may return HTTP 403 when fetching songs, and SyncDisBoi will skip those playlist songs.
+- Spotify may omit the user `country` field on `GET /me` in Development Mode. If country checks block synchronization, use `--diff-country` to allow sync across platforms. Be aware this can reduce matching accuracy for cross-market catalogs.
 
 ### Youtube Music API setup
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -41,7 +41,7 @@ pub enum MusicPlatformSrc {
         /// The client secret for the Youtube API application
         #[arg(long, env = "YTMUSIC_CLIENT_SECRET", conflicts_with = "headers")]
         client_secret: Option<String>,
-        /// Clear the cached ytmusic_oauth.json file
+        /// Clear the cached `ytmusic_oauth.json` file
         #[arg(long, requires = "client_id", requires = "client_secret")]
         clear_cache: bool,
         /// The destination music platform
@@ -101,7 +101,7 @@ pub enum MusicPlatformDst {
         /// The client secret for the Youtube API application
         #[arg(long, env = "YTMUSIC_CLIENT_SECRET", conflicts_with = "headers")]
         client_secret: Option<String>,
-        /// Clear the cached ytmusic_oauth.json file
+        /// Clear the cached `ytmusic_oauth.json` file
         #[arg(long, requires = "client_id", requires = "client_secret")]
         clear_cache: bool,
     },

--- a/src/spotify/mod.rs
+++ b/src/spotify/mod.rs
@@ -25,7 +25,7 @@ use crate::music_api::{
     Song, Songs,
 };
 use crate::spotify::model::SpotifySearchResponse;
-use crate::utils::debug_response_json;
+use crate::utils::{debug_response_json, read_response_body_debug};
 
 pub struct SpotifyApi {
     client: reqwest::Client,
@@ -102,7 +102,13 @@ impl SpotifyApi {
         let me_res: SpotifyUserResponse = spotify_api
             .make_request_json("/me", &HttpMethod::Get(&[]), 50, 0)
             .await?;
-        spotify_api.country_code = me_res.country;
+        spotify_api.country_code = me_res.country.unwrap_or_default();
+        if spotify_api.country_code.is_empty() {
+            warn!(
+                "Spotify user profile has no country (common on Web API Development Mode). \
+                 Cross-platform country checks are skipped unless you use --diff-country."
+            );
+        }
 
         Ok(spotify_api)
     }
@@ -245,6 +251,70 @@ impl SpotifyApi {
         Ok(res)
     }
 
+    /// Single `GET` page for [`GET /playlists/{id}/items`](https://developer.spotify.com/documentation/web-api/reference/get-playlists-items).
+    /// Returns `Ok(None)` on HTTP **403** (playlist followed but not owned — common under Feb 2026 Dev Mode).
+    async fn try_fetch_playlist_items_page(
+        &self,
+        path: &str,
+        limit: usize,
+        offset: usize,
+    ) -> Result<Option<SpotifyPageResponse<SpotifySongItemResponse>>> {
+        let platform = Self::RES_DEBUG_FILENAME;
+        loop {
+            let endpoint = Self::build_endpoint(path);
+            let request = self
+                .client
+                .get(endpoint)
+                .query(&[("limit", limit), ("offset", offset)]);
+            let res = request.send().await?;
+            let status = res.status();
+            if status == StatusCode::TOO_MANY_REQUESTS {
+                self.api_rate_wait(&res).await?;
+                continue;
+            }
+            let body = read_response_body_debug(&self.config, res, platform).await?;
+            if status == StatusCode::FORBIDDEN {
+                if offset == 0 {
+                    warn!(
+                        "Skipping playlist (HTTP 403): Spotify Web API (Feb 2026+) only returns \
+                         tracks for playlists you **own** or **collaborate** on — not playlists you \
+                         only **follow**. Export/sync will omit this playlist's tracks. Path: {path}"
+                    );
+                } else {
+                    return Err(eyre!(
+                        "Spotify returned HTTP 403 on a later page of playlist items (offset {offset}). Path: {path}"
+                    ));
+                }
+                return Ok(None);
+            }
+            let ok = status == StatusCode::OK
+                || status == StatusCode::CREATED
+                || status == StatusCode::NO_CONTENT;
+            if !ok {
+                let preview = String::from_utf8_lossy(&body);
+                let mut chars = preview.chars();
+                let mut msg: String = chars.by_ref().take(2048).collect();
+                if chars.next().is_some() {
+                    msg.push_str("...");
+                }
+                return Err(eyre!("Spotify API error (HTTP {status}): {msg}"));
+            }
+            if body.is_empty() {
+                return Err(eyre!(
+                    "Spotify returned an empty body with HTTP {status} for {path}"
+                ));
+            }
+            let page: SpotifyPageResponse<SpotifySongItemResponse> =
+                serde_json::from_slice(&body).map_err(|e| {
+                    if self.config.debug {
+                        let _ = std::fs::write(format!("debug/{platform}_last_error.json"), &body);
+                    }
+                    eyre!("failed to parse Spotify JSON response: {e}")
+                })?;
+            return Ok(Some(page));
+        }
+    }
+
     async fn api_rate_wait(&self, res: &Response) -> Result<()> {
         let headers = res.headers();
         let sleep_time = headers
@@ -287,10 +357,30 @@ impl SpotifyApi {
             // Retry request
             return self.make_request_json(path, method, limit, offset).await;
         }
-        let obj = debug_response_json(&self.config, res, Self::RES_DEBUG_FILENAME).await?;
-        if status != StatusCode::OK && status != StatusCode::CREATED {
-            return Err(eyre!("Invalid HTTP status: {}", status));
+        let platform = Self::RES_DEBUG_FILENAME;
+        let body = read_response_body_debug(&self.config, res, platform).await?;
+        let ok = status == StatusCode::OK
+            || status == StatusCode::CREATED
+            || status == StatusCode::NO_CONTENT;
+        if !ok {
+            let preview = String::from_utf8_lossy(&body);
+            let mut chars = preview.chars();
+            let mut msg: String = chars.by_ref().take(2048).collect();
+            if chars.next().is_some() {
+                msg.push_str("...");
+            }
+            return Err(eyre!("Spotify API error (HTTP {status}): {msg}"));
         }
+        let obj: T = if body.is_empty() || status == StatusCode::NO_CONTENT {
+            serde_json::from_str("null")?
+        } else {
+            serde_json::from_slice(&body).map_err(|e| {
+                if self.config.debug {
+                    let _ = std::fs::write(format!("debug/{platform}_last_error.json"), &body);
+                }
+                eyre!("failed to parse Spotify JSON response: {e}")
+            })?
+        };
         Ok(obj)
     }
 }
@@ -337,11 +427,24 @@ impl MusicApi for SpotifyApi {
     }
 
     async fn get_playlist_songs(&self, id: &str) -> Result<Vec<Song>> {
-        let path = format!("/playlists/{}/tracks", id);
-        let res: SpotifyPageResponse<SpotifySongItemResponse> = self
-            .paginated_request(&path, HttpMethod::Get(&[]), 50)
-            .await?;
-        let songs: Songs = res.try_into()?;
+        let path = format!("/playlists/{id}/items");
+        let Some(mut page) = self.try_fetch_playlist_items_page(&path, 50, 0).await? else {
+            return Ok(vec![]);
+        };
+        while page.next.is_some() {
+            let offset = page.items.len();
+            let Some(next) = self
+                .try_fetch_playlist_items_page(&path, 50, offset)
+                .await?
+            else {
+                return Err(eyre!(
+                    "Spotify denied access when fetching the next page of playlist items \
+                     (playlist id {id}, offset {offset}) after a successful first page"
+                ));
+            };
+            page.merge(next);
+        }
+        let songs: Songs = page.try_into()?;
         Ok(songs.0)
     }
 
@@ -355,7 +458,7 @@ impl MusicApi for SpotifyApi {
             .map(|song| format!("spotify:track:{}", song.id))
             .collect();
 
-        let path = format!("/playlists/{}/tracks", playlist.id);
+        let path = format!("/playlists/{}/items", playlist.id);
         for u in uris.as_slice().chunks(100) {
             let body = json!({
                 "uris": u,
@@ -383,9 +486,9 @@ impl MusicApi for SpotifyApi {
                 json!({ "uri": uri })
             })
             .collect();
-        let path = format!("/playlists/{}/tracks", playlist.id);
+        let path = format!("/playlists/{}/items", playlist.id);
         let body = json!({
-            "tracks": uris,
+            "items": uris,
         });
         self.make_request_json::<SpotifySnapshotResponse>(&path, &HttpMethod::Delete(&body), 50, 0)
             .await?;
@@ -393,11 +496,11 @@ impl MusicApi for SpotifyApi {
     }
 
     async fn delete_playlist(&self, playlist: Playlist) -> Result<()> {
-        let path = format!("/playlists/{}/followers", playlist.id);
+        let uri = format!("spotify:playlist:{}", playlist.id);
         let body = json!({
-            "playlist_id": playlist.id,
+            "uris": [uri],
         });
-        self.make_request_json::<()>(&path, &HttpMethod::Delete(&body), 50, 0)
+        self.make_request_json::<()>("/me/library", &HttpMethod::Delete(&body), 50, 0)
             .await?;
         Ok(())
     }
@@ -472,11 +575,14 @@ impl MusicApi for SpotifyApi {
     async fn add_likes(&self, songs: &[Song]) -> Result<()> {
         // NOTE: A maximum of 50 items can be specified in one request
         for songs_chunk in songs.chunks(50) {
-            let ids: Vec<&str> = songs_chunk.iter().map(|s| s.id.as_str()).collect();
+            let uris: Vec<String> = songs_chunk
+                .iter()
+                .map(|s| format!("spotify:track:{}", s.id))
+                .collect();
             let body = json!({
-                "ids": ids,
+                "uris": uris,
             });
-            self.make_request_json::<()>("/me/tracks", &HttpMethod::Put(&body), 50, 0)
+            self.make_request_json::<()>("/me/library", &HttpMethod::Put(&body), 50, 0)
                 .await?;
         }
         Ok(())
@@ -497,19 +603,28 @@ mod tests {
 
     use super::*;
     use crate::yt_music::YtMusicApi;
+    use crate::ConfigArgs;
 
     #[tokio::test]
+    #[ignore = "requires live Spotify + YouTube Music credentials and a TestSpotify playlist"]
     async fn test_spotify_search_from_ytmusic() {
+        let config = ConfigArgs {
+            debug: false,
+            like_all: false,
+            sync_likes: false,
+            diff_country: false,
+            proxy: None,
+        };
         let yt_client_id = env::var("YTMUSIC_CLIENT_ID").unwrap();
         let yt_client_secret = env::var("YTMUSIC_CLIENT_SECRET").unwrap();
         let config_dir = dirs::config_dir().unwrap();
-        let oauth_token_path = config_dir.join("SyncDisBoi").join("ytmusic_oauth.json");
+        let yt_oauth = config_dir.join("SyncDisBoi").join("ytmusic_oauth.json");
         let ytmusic = YtMusicApi::new_oauth(
             &yt_client_id,
             &yt_client_secret,
-            oauth_token_path,
+            yt_oauth,
             false,
-            None,
+            config.clone(),
         )
         .await
         .unwrap();
@@ -520,9 +635,17 @@ mod tests {
 
         let spotify_client_id = env::var("SPOTIFY_CLIENT_ID").unwrap();
         let spotify_secret = env::var("SPOTIFY_CLIENT_SECRET").unwrap();
-        let spotify = SpotifyApi::new(&spotify_client_id, &spotify_secret, None)
-            .await
-            .unwrap();
+        let spotify_oauth = config_dir.join("SyncDisBoi").join("spotify_oauth.json");
+        let spotify = SpotifyApi::new(
+            &spotify_client_id,
+            &spotify_secret,
+            spotify_oauth,
+            SpotifyApi::REDIRECT_URI_URL,
+            false,
+            config,
+        )
+        .await
+        .unwrap();
 
         let songs = spotify.search_songs(&songs).await.unwrap();
         let correct_ids = [

--- a/src/spotify/model.rs
+++ b/src/spotify/model.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Deserializer};
+use serde_json::Value;
 
 #[derive(Deserialize, Debug)]
 pub struct SpotifyEmptyResponse {}
@@ -6,9 +7,13 @@ pub struct SpotifyEmptyResponse {}
 #[derive(Deserialize, Debug)]
 #[allow(dead_code)]
 pub struct SpotifyUserResponse {
-    pub country: String,
+    /// Omitted on Spotify Web API Development Mode (Feb 2026+); see changelog.
+    #[serde(default)]
+    pub country: Option<String>,
     pub display_name: Option<String>,
-    pub email: String,
+    /// Omitted on Spotify Web API Development Mode (Feb 2026+); see changelog.
+    #[serde(default)]
+    pub email: Option<String>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -55,9 +60,14 @@ pub struct SpotifyPlaylistResponse {
     pub public: Option<bool>,
 }
 
+/// One row from `GET /playlists/{id}/items` or `GET /me/tracks`.
+/// Feb 2026+: playlist rows use `item` (track or episode); legacy `track` is still accepted.
 #[derive(Deserialize, Debug)]
 pub struct SpotifySongItemResponse {
-    pub track: Option<SpotifySongResponse>,
+    #[serde(default)]
+    pub item: Option<Value>,
+    #[serde(default)]
+    pub track: Option<Value>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -68,7 +78,9 @@ pub struct SpotifySongResponse {
     pub duration_ms: usize,
     pub artists: Vec<SpotifyArtistResponse>,
     pub album: SpotifyAlbumResponse,
-    pub external_ids: SpotifyExternalIdsResponse,
+    /// May be omitted in some API modes (see Spotify changelog).
+    #[serde(default)]
+    pub external_ids: Option<SpotifyExternalIdsResponse>,
 }
 
 #[derive(Deserialize, Debug)]

--- a/src/spotify/response.rs
+++ b/src/spotify/response.rs
@@ -1,7 +1,8 @@
 use std::convert::TryInto;
 
-use color_eyre::eyre::{Error, OptionExt, Result};
+use color_eyre::eyre::{Error, OptionExt, Result, eyre};
 use serde::Deserialize;
+use serde_json::Value;
 use tracing::{debug, error};
 
 use super::model::{
@@ -86,11 +87,24 @@ impl TryInto<Playlist> for SpotifyPlaylistResponse {
     }
 }
 
+fn value_to_spotify_track(v: Value) -> Result<SpotifySongResponse> {
+    if let Some(t) = v.get("type").and_then(Value::as_str)
+        && t != "track"
+    {
+        return Err(eyre!("skipping non-track playlist/library entry (type={t})"));
+    }
+    serde_json::from_value(v).map_err(|e| eyre!("invalid track JSON: {e}"))
+}
+
 impl TryInto<Song> for SpotifySongItemResponse {
     type Error = Error;
 
     fn try_into(self) -> Result<Song, Self::Error> {
-        self.track.ok_or_eyre("null track metadata")?.try_into()
+        let payload = self
+            .item
+            .or(self.track)
+            .ok_or_eyre("null track metadata (no item or track)")?;
+        value_to_spotify_track(payload)?.try_into()
     }
 }
 
@@ -117,7 +131,11 @@ impl TryInto<Song> for SpotifySongResponse {
             name: self.album.name,
         };
 
-        let isrc = clean_isrc(self.external_ids.isrc);
+        let isrc = clean_isrc(
+            self.external_ids
+                .as_ref()
+                .and_then(|e| e.isrc.clone()),
+        );
 
         Ok(Song {
             source: MusicApiType::Spotify,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -86,6 +86,22 @@ pub fn dedup_songs(songs: &mut Vec<Song>) -> bool {
     dups
 }
 
+/// Reads the full HTTP body. When `config.debug` is true, writes it to
+/// `debug/{platform}_last_res.json`.
+pub async fn read_response_body_debug(
+    config: &ConfigArgs,
+    res: reqwest::Response,
+    platform: &str,
+) -> Result<Vec<u8>> {
+    const DEBUG_FOLDER: &str = "debug";
+
+    let full = res.bytes().await?.to_vec();
+    if config.debug {
+        std::fs::write(format!("{DEBUG_FOLDER}/{platform}_last_res.json"), &full)?;
+    }
+    Ok(full)
+}
+
 pub async fn debug_response_json<T>(
     config: &ConfigArgs,
     res: reqwest::Response,


### PR DESCRIPTION
- Playlist tracks: GET/POST/DELETE use /playlists/{id}/items; delete uses items body key
- Likes and unfollow: PUT/DELETE /me/library with spotify: URIs
- Tolerate missing GET /me country/email; clearer errors when JSON parse fails
- Skip playlist track fetch on HTTP 403 for followed-only playlists (Dev Mode)
- AI-assisted: parts of implementation/docs were generated with AI and reviewed/validated/tested by me.